### PR TITLE
Fix paging by adding options to options.params

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,8 +44,8 @@ exports.sourceNodes = ( { actions, createNodeId, createContentDigest },
     
         if (typeof data.LastEvaluatedKey != "undefined") {
           console.log("Scanning for more...");
-          params.ExclusiveStartKey = data.LastEvaluatedKey;
-          docClient.scan(params, onScan);
+          options.params.ExclusiveStartKey = data.LastEvaluatedKey;
+          docClient.scan(options.params, onScan);
         } else {
           resolve()
         }


### PR DESCRIPTION
Addresses #3 

This module fails if DynamoDB has to implement paging. You can recreate the error by trying to source from a DynamoDB that has over 1mb of data (1mb is [the limit for one payload](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)).

The failure is that `params` is undefined. Easy fix -- this PR simply changes `params` to `options.params` and then paging works fine.